### PR TITLE
Update mkdocs-material

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,9 +22,9 @@ jobs:
     if: github.ref == 'refs/heads/master'
     steps:
       - name: Checkout master
-        uses: actions/checkout@v2
-
+        uses: actions/checkout@v1
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          CUSTOM_DOMAIN: docs.dasch.swiss

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,6 @@ theme:
     primary: 'deep purple'
     accent: 'deep purple'
   features:
-    - tabs
+    - navigation.tabs
 extra_css:
   - 'assets/style/theme.css'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 mkdocs==1.1.2
-mkdocs-material
+mkdocs-material==6.0.1


### PR DESCRIPTION
I figured out that the Github actions script for deploying the docs uses the latest version of mkdocs-material which contains a breaking change. So I had to fix the docs.