### PR TITLE
DSP-920 Renaming default github branch to "main"

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,1 @@
-resolves [DSP-xy](https://dasch.myjetbrains.com/youtrack/issue/DSP-xy)
+resolves DSP-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,10 +18,10 @@ jobs:
     name: Publish documentation
     needs: build
     runs-on: ubuntu-latest
-    # Publish and deploy docs as Pull Requests are merged into "master"
-    if: github.ref == 'refs/heads/master'
+    # Publish and deploy docs as Pull Requests are merged into "main" branch
+    if: github.ref == 'refs/heads/main'
     steps:
-      - name: Checkout master
+      - name: Checkout main
         uses: actions/checkout@v1
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master

--- a/README.md
+++ b/README.md
@@ -98,6 +98,6 @@ make build-docs
 
 ### Deploying github page
 
-On each push into `master` branch, a Github action script will build and deploy the documentation on [docs.dasch.swiss](https://docs.dasch.swiss). Behind the scenes, MkDocs builds the documentation and use the [ghp-import](https://github.com/davisp/ghp-import) tool to commit them to the gh-pages branch and then push the gh-pages branch to GitHub. That's it!
+On each push into `main` branch, a Github action script will build and deploy the documentation on [docs.dasch.swiss](https://docs.dasch.swiss). Behind the scenes, MkDocs builds the documentation and use the [ghp-import](https://github.com/davisp/ghp-import) tool to commit them to the gh-pages branch and then push the gh-pages branch to GitHub. That's it!
 
-Be aware that you have to review the built site before pushing it to `master` branch! Please create an own branch for any changes and review it before merging!
+Be aware that you have to review the built site before pushing it to `main` branch! Please create an own branch for any changes and review it before merging!

--- a/docs/developers/dsp/contribution/index.md
+++ b/docs/developers/dsp/contribution/index.md
@@ -10,11 +10,11 @@ The DSP software is developed under git version control using [GitHub](https://g
 
 In all these repositories, we follow the [GitHub flow](https://guides.github.com/introduction/flow/) recommondations:
 
-1. [Create a branch from master](#create-branch-guidelines)
+1. [Create a branch from main](#create-branch-guidelines)
 1. [Add commits](#git-commit-guidelines)
 1. [Open a pull request](#pull-request-guidelines)
 1. Discuss and review your code
-1. Merge into `master` branch
+1. Merge into `main` branch
 
 ## Create Branch Guidelines
 
@@ -98,7 +98,7 @@ Please convert the pull request to draft as long it is not ready for reviewing. 
 
 ### Branch protection rules
 
-The main branch of each repo (it's usually the `master` branch) is protected by the following rules:
+The main branch of each repo (it's usually the `main` branch) is protected by the following rules:
 
 - Require pull request reviews before merging
     - At least from one reviewer
@@ -124,7 +124,7 @@ With each push to GitHub, the tests of the repository are executed. Successfull 
 
 ### Release notes
 
-After each push into the master branch &mdash; after each merge from a pull request &mdash; the release notes for the next release are updated. This release called "Next release" is a draft and can be used to publish the [real release](#release) later.
+After each push into the main branch &mdash; after each merge from a pull request &mdash; the release notes for the next release are updated. This release called "Next release" is a draft and can be used to publish the [real release](#release) later.
 
 The GitHub action we use for this step is [release-drafter](https://github.com/marketplace/actions/release-drafter).
 


### PR DESCRIPTION
resolves DSP-920

- Default branch is already set to "main" branch
&rarr; <https://github.com/dasch-swiss/dsp-docs/settings/branches>
- Branch protections rule is set to "main" branch too
&rarr; <https://github.com/dasch-swiss/dsp-docs/settings/branches>

- The base branch of all open PRs is already set to "main" branch