### PR TITLE
fix: add ref to main branch for dsp-tools submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,3 +9,4 @@
 [submodule "dsp/dsp-tools"]
 	path = dsp/dsp-tools
 	url = https://github.com/dasch-swiss/dsp-tools
+	branch = main


### PR DESCRIPTION
Add the reference to 'main' branch for dsp-tools submodules
