### PR TITLE
chore: use a version tag for DSP-TOOLS instead of a commit hash

### DIFF
--- a/release.mk
+++ b/release.mk
@@ -3,6 +3,6 @@
 DSP := "2024.08.02"
 API := "v30.18.4"
 APP := "v11.18.2"
-TOOLS := "fdf58b9b8b7b244f3a99cc3629ffdb4e7d02d612"
+TOOLS := "v9.0.2"
 INGEST := "v0.12.3"
 


### PR DESCRIPTION
A while ago, we temporarily introduced a commit hash for DSP-TOOLS. The plan was that at the following deployment, the hash would be replaced by a version tag, like it was before. 

The person who did the last deployment didn't know that, so this PR does it.