### PR TITLE
fix: unblock bump auto-merge + event-driven docs release announcement (DEV-6438)

### DIFF
--- a/.github/workflows/announce-release.yml
+++ b/.github/workflows/announce-release.yml
@@ -1,0 +1,69 @@
+name: announce-release
+
+# Posts the public "DSP-DOCS X released and deployed" announcement only once the
+# docs site is actually live. GitHub Pages (deploy-from-branch) emits a
+# `deployment_status` event whenever the github-pages deployment changes state;
+# we act on `success` only, so the announcement and its "Live docs" link are
+# never premature. Event-driven — replaces the polling that used to live in
+# deploy.yml. Note: deployment_status workflows run from the default branch, so
+# this takes effect once merged to main.
+on:
+  deployment_status:
+
+permissions:
+  contents: read  # read versions.json from gh-pages to resolve the DSP version
+
+jobs:
+  announce:
+    name: Announce docs release
+    # Only the github-pages environment, only when it actually went live.
+    if: >-
+      github.event.deployment_status.state == 'success'
+      && github.event.deployment_status.environment == 'github-pages'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve deployed DSP version
+        id: dsp
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.event.deployment.sha }}
+        run: |
+          set -euo pipefail
+          # `make deploy` runs `mike deploy <DSP> latest --update-aliases`, so on
+          # gh-pages the versions.json entry aliased "latest" is the just-deployed
+          # DSP. Read it at the exact commit this deployment published.
+          dsp=$(gh api "repos/$REPO/contents/versions.json?ref=$SHA" --jq '.content' \
+                | base64 -d \
+                | jq -r 'map(select(.aliases | index("latest"))) | .[0].version // empty')
+          if [[ -z "$dsp" ]]; then
+            echo "::notice::no version aliased 'latest' in versions.json@$SHA; skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "::notice::resolved DSP=$dsp"
+          echo "value=$dsp" >> "$GITHUB_OUTPUT"
+
+      - name: Post release announcement to public Chat room
+        if: steps.dsp.outputs.skip != 'true'
+        env:
+          PUBLIC_WEBHOOK: ${{ secrets.GOOGLE_CHAT_DSP_RELEASES_WEBHOOK_URL }}
+          DSP: ${{ steps.dsp.outputs.value }}
+        run: |
+          set -euo pipefail
+          curl -fsSL -X POST -H 'Content-Type: application/json' \
+            -d "$(jq -n --arg dsp "$DSP" '{text: "📚 *DSP-DOCS* \($dsp) released and deployed\n\n<https://docs.dasch.swiss/\($dsp)/|Live docs>"}')" \
+            "$PUBLIC_WEBHOOK"
+
+      - name: Notify on failure (internal)
+        if: failure()
+        env:
+          INTERNAL_WEBHOOK: ${{ secrets.GOOGLE_CHAT_DSP_RELEASE_INTERNAL_WEBHOOK_URL }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          run_url="https://github.com/$REPO/actions/runs/$RUN_ID"
+          curl -fsSL -X POST -H 'Content-Type: application/json' \
+            -d "$(jq -n --arg text "❌ announce-release.yml failed · <$run_url|view run>" '{text:$text}')" \
+            "$INTERNAL_WEBHOOK"

--- a/.github/workflows/bump-release.yml
+++ b/.github/workflows/bump-release.yml
@@ -149,6 +149,7 @@ jobs:
           echo "branch=$branch" >> "$GITHUB_OUTPUT"
 
       - name: Commit, push, open PR, enable auto-merge
+        id: pr
         if: steps.prep.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ steps.app-token-write.outputs.token }}
@@ -223,11 +224,26 @@ jobs:
             echo "::error::No open PR found for branch $BRANCH after create"
             exit 1
           fi
+          echo "url=$pr_url" >> "$GITHUB_OUTPUT"
 
           if ! gh pr merge --auto --squash "$pr_url"; then
             echo "::warning::auto-merge enable failed; verifying state"
             gh pr view "$pr_url" --json autoMergeRequest --jq .autoMergeRequest || true
           fi
+
+      # main requires 1 approving review. The PR is authored by the DaSCH Bot
+      # App, which GitHub forbids from approving its own PR, so the armed
+      # auto-merge would wait forever. The daschbot user (a distinct identity,
+      # admin on dsp-docs) submits the approval that unblocks it. DASCHBOT_PAT
+      # must be available to this repo (org secret scoped to dsp-docs).
+      - name: Approve PR so auto-merge can complete
+        if: steps.prep.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
+          PR_URL: ${{ steps.pr.outputs.url }}
+        run: |
+          set -euo pipefail
+          gh pr review --approve "$PR_URL"
 
       - name: Notify on failure (internal)
         if: failure()

--- a/.github/workflows/bump-release.yml
+++ b/.github/workflows/bump-release.yml
@@ -149,7 +149,6 @@ jobs:
           echo "branch=$branch" >> "$GITHUB_OUTPUT"
 
       - name: Commit, push, open PR, enable auto-merge
-        id: pr
         if: steps.prep.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ steps.app-token-write.outputs.token }}
@@ -224,26 +223,14 @@ jobs:
             echo "::error::No open PR found for branch $BRANCH after create"
             exit 1
           fi
-          echo "url=$pr_url" >> "$GITHUB_OUTPUT"
 
+          # Auto-merge completes without a review because the DaSCH Bot App is a
+          # bypass actor for the required-PR-review rule on main (configured in
+          # branch protection / ruleset). No PAT or self-approval is involved.
           if ! gh pr merge --auto --squash "$pr_url"; then
             echo "::warning::auto-merge enable failed; verifying state"
             gh pr view "$pr_url" --json autoMergeRequest --jq .autoMergeRequest || true
           fi
-
-      # main requires 1 approving review. The PR is authored by the DaSCH Bot
-      # App, which GitHub forbids from approving its own PR, so the armed
-      # auto-merge would wait forever. The daschbot user (a distinct identity,
-      # admin on dsp-docs) submits the approval that unblocks it. DASCHBOT_PAT
-      # must be available to this repo (org secret scoped to dsp-docs).
-      - name: Approve PR so auto-merge can complete
-        if: steps.prep.outputs.skip != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
-          PR_URL: ${{ steps.pr.outputs.url }}
-        run: |
-          set -euo pipefail
-          gh pr review --approve "$PR_URL"
 
       - name: Notify on failure (internal)
         if: failure()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           set -euo pipefail
           curl -fsSL -X POST -H 'Content-Type: application/json' \
-            -d "$(jq -n --arg dsp "$DSP" '{text: "📚 *DSP-DOCS* \($dsp) released\n\n<https://docs.dasch.swiss/\($dsp)/|Live docs>"}')" \
+            -d "$(jq -n --arg dsp "$DSP" '{text: "📚 *DSP-DOCS* \($dsp) released and deployed\n\n<https://docs.dasch.swiss/\($dsp)/|Live docs>"}')" \
             "$PUBLIC_WEBHOOK"
 
   notify-failure:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,6 +54,29 @@ jobs:
           dsp=$(echo "$MSG" | sed -nE 's/^deploy: bump docs to ([0-9]{4}\.[0-9]{2}\.[0-9]{2}).*$/\1/p')
           [[ -n "$dsp" ]] || dsp='(unknown)'
           echo "value=$dsp" >> "$GITHUB_OUTPUT"
+      - name: Wait for live docs to be served
+        env:
+          DSP: ${{ steps.dsp.outputs.value }}
+        run: |
+          set -euo pipefail
+          # `make deploy` only pushes the built site to gh-pages. The public
+          # site (docs.dasch.swiss, custom domain) is then re-published by a
+          # separate GitHub Pages build + CDN propagation, which lags by minutes.
+          # Poll the versioned URL until it actually serves so the announcement
+          # and its "Live docs" link are never premature. Fail-closed: on timeout
+          # we exit non-zero, so the public post is skipped and notify-failure
+          # raises an internal alert instead of announcing a dead link.
+          url="https://docs.dasch.swiss/${DSP}/"
+          deadline=$(( $(date +%s) + 300 ))  # 5-minute budget
+          until curl -fsS -o /dev/null -H 'Cache-Control: no-cache' "${url}?cb=$(date +%s)"; do
+            if (( $(date +%s) >= deadline )); then
+              echo "::error::Live docs not serving at $url after 5 min; skipping announcement"
+              exit 1
+            fi
+            echo "waiting for $url ..."
+            sleep 15
+          done
+          echo "Live: $url"
       - name: Post release announcement to public Chat room
         env:
           PUBLIC_WEBHOOK: ${{ secrets.GOOGLE_CHAT_DSP_RELEASES_WEBHOOK_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,17 +60,15 @@ jobs:
       - name: Wait for GitHub Pages to publish the new site
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DSP: ${{ steps.dsp.outputs.value }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           # `make deploy` only pushes the built site to gh-pages. The public site
           # (docs.dasch.swiss) is then published by the separate "pages build and
           # deployment" workflow (github-pages environment), which lags by ~10 min.
-          # Gate the announcement on THAT deployment reaching "success", then
-          # confirm the URL actually serves (CDN). Fail-closed: on timeout or a
-          # failed deployment we exit non-zero, so the public post is skipped and
-          # notify-failure raises an internal alert instead of announcing a dead link.
+          # Gate the announcement on THAT deployment reaching "success". Fail-closed:
+          # on timeout or a failed deployment we exit non-zero, so the public post is
+          # skipped and notify-failure raises an internal alert.
           sha=$(gh api "repos/$REPO/branches/gh-pages" --jq '.commit.sha')
           echo "gh-pages HEAD: $sha"
           deadline=$(( $(date +%s) + 1200 ))  # 20-minute budget
@@ -96,15 +94,6 @@ jobs:
             (( $(date +%s) >= deadline )) && { echo "::error::pages deployment not done within budget"; exit 1; }
             sleep 20
           done
-
-          # 3) Confirm the versioned URL actually serves (covers CDN propagation).
-          url="https://docs.dasch.swiss/${DSP}/"
-          until curl -fsS -o /dev/null -H 'Cache-Control: no-cache' "${url}?cb=$(date +%s)"; do
-            (( $(date +%s) >= deadline )) && { echo "::error::live docs not serving at $url within budget"; exit 1; }
-            echo "waiting for $url ..."
-            sleep 15
-          done
-          echo "Live: $url"
       - name: Post release announcement to public Chat room
         env:
           PUBLIC_WEBHOOK: ${{ secrets.GOOGLE_CHAT_DSP_RELEASES_WEBHOOK_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,76 +37,13 @@ jobs:
       - name: Deploy docs
         run: make deploy
 
-  send-chat-notification:
-    name: Send google chat notification
-    needs: [deploy]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read      # read gh-pages HEAD sha
-      deployments: read   # poll github-pages deployment status
-    # Restrict to canonical bump-docs commits so reverts (e.g. "deploy: revert ...")
-    # don't post "(unknown) released" to the public announcements channel.
-    # Quoted because the embedded colon trips strict YAML parsers (yamllint, PyYAML).
-    if: "success() && startsWith(github.event.head_commit.message, 'deploy: bump docs to')"
-    steps:
-      - name: Extract DSP from commit subject
-        id: dsp
-        env:
-          MSG: ${{ github.event.head_commit.message }}
-        run: |
-          dsp=$(echo "$MSG" | sed -nE 's/^deploy: bump docs to ([0-9]{4}\.[0-9]{2}\.[0-9]{2}).*$/\1/p')
-          [[ -n "$dsp" ]] || dsp='(unknown)'
-          echo "value=$dsp" >> "$GITHUB_OUTPUT"
-      - name: Wait for GitHub Pages to publish the new site
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          # `make deploy` only pushes the built site to gh-pages. The public site
-          # (docs.dasch.swiss) is then published by the separate "pages build and
-          # deployment" workflow (github-pages environment), which lags by ~10 min.
-          # Gate the announcement on THAT deployment reaching "success". Fail-closed:
-          # on timeout or a failed deployment we exit non-zero, so the public post is
-          # skipped and notify-failure raises an internal alert.
-          sha=$(gh api "repos/$REPO/branches/gh-pages" --jq '.commit.sha')
-          echo "gh-pages HEAD: $sha"
-          deadline=$(( $(date +%s) + 1200 ))  # 20-minute budget
-
-          # 1) Wait for the github-pages deployment for this commit to be created.
-          dep_id=""
-          while [[ -z "$dep_id" ]]; do
-            dep_id=$(gh api "repos/$REPO/deployments?environment=github-pages&sha=$sha&per_page=1" --jq '.[0].id // empty')
-            [[ -n "$dep_id" ]] && break
-            (( $(date +%s) >= deadline )) && { echo "::error::no github-pages deployment for $sha within budget"; exit 1; }
-            echo "waiting for pages deployment to be created ..."
-            sleep 20
-          done
-
-          # 2) Wait for that deployment's latest status to be success.
-          while :; do
-            state=$(gh api "repos/$REPO/deployments/$dep_id/statuses?per_page=1" --jq '.[0].state // "pending"')
-            echo "github-pages deployment state: $state"
-            case "$state" in
-              success)        break ;;
-              error|failure)  echo "::error::github-pages deployment $state"; exit 1 ;;
-            esac
-            (( $(date +%s) >= deadline )) && { echo "::error::pages deployment not done within budget"; exit 1; }
-            sleep 20
-          done
-      - name: Post release announcement to public Chat room
-        env:
-          PUBLIC_WEBHOOK: ${{ secrets.GOOGLE_CHAT_DSP_RELEASES_WEBHOOK_URL }}
-          DSP: ${{ steps.dsp.outputs.value }}
-        run: |
-          set -euo pipefail
-          curl -fsSL -X POST -H 'Content-Type: application/json' \
-            -d "$(jq -n --arg dsp "$DSP" '{text: "📚 *DSP-DOCS* \($dsp) released and deployed\n\n<https://docs.dasch.swiss/\($dsp)/|Live docs>"}')" \
-            "$PUBLIC_WEBHOOK"
+  # The public release announcement is posted by announce-release.yml, which
+  # triggers on the github-pages `deployment_status == success` event — i.e.
+  # only once the site is actually live. See that workflow for details.
 
   notify-failure:
     name: Notify on deploy failure (internal)
-    needs: [deploy, send-chat-notification]
+    needs: [deploy]
     runs-on: ubuntu-latest
     if: failure()
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,9 @@ jobs:
     name: Send google chat notification
     needs: [deploy]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read      # read gh-pages HEAD sha
+      deployments: read   # poll github-pages deployment status
     # Restrict to canonical bump-docs commits so reverts (e.g. "deploy: revert ...")
     # don't post "(unknown) released" to the public announcements channel.
     # Quoted because the embedded colon trips strict YAML parsers (yamllint, PyYAML).
@@ -54,25 +57,50 @@ jobs:
           dsp=$(echo "$MSG" | sed -nE 's/^deploy: bump docs to ([0-9]{4}\.[0-9]{2}\.[0-9]{2}).*$/\1/p')
           [[ -n "$dsp" ]] || dsp='(unknown)'
           echo "value=$dsp" >> "$GITHUB_OUTPUT"
-      - name: Wait for live docs to be served
+      - name: Wait for GitHub Pages to publish the new site
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DSP: ${{ steps.dsp.outputs.value }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          # `make deploy` only pushes the built site to gh-pages. The public
-          # site (docs.dasch.swiss, custom domain) is then re-published by a
-          # separate GitHub Pages build + CDN propagation, which lags by minutes.
-          # Poll the versioned URL until it actually serves so the announcement
-          # and its "Live docs" link are never premature. Fail-closed: on timeout
-          # we exit non-zero, so the public post is skipped and notify-failure
-          # raises an internal alert instead of announcing a dead link.
+          # `make deploy` only pushes the built site to gh-pages. The public site
+          # (docs.dasch.swiss) is then published by the separate "pages build and
+          # deployment" workflow (github-pages environment), which lags by ~10 min.
+          # Gate the announcement on THAT deployment reaching "success", then
+          # confirm the URL actually serves (CDN). Fail-closed: on timeout or a
+          # failed deployment we exit non-zero, so the public post is skipped and
+          # notify-failure raises an internal alert instead of announcing a dead link.
+          sha=$(gh api "repos/$REPO/branches/gh-pages" --jq '.commit.sha')
+          echo "gh-pages HEAD: $sha"
+          deadline=$(( $(date +%s) + 1200 ))  # 20-minute budget
+
+          # 1) Wait for the github-pages deployment for this commit to be created.
+          dep_id=""
+          while [[ -z "$dep_id" ]]; do
+            dep_id=$(gh api "repos/$REPO/deployments?environment=github-pages&sha=$sha&per_page=1" --jq '.[0].id // empty')
+            [[ -n "$dep_id" ]] && break
+            (( $(date +%s) >= deadline )) && { echo "::error::no github-pages deployment for $sha within budget"; exit 1; }
+            echo "waiting for pages deployment to be created ..."
+            sleep 20
+          done
+
+          # 2) Wait for that deployment's latest status to be success.
+          while :; do
+            state=$(gh api "repos/$REPO/deployments/$dep_id/statuses?per_page=1" --jq '.[0].state // "pending"')
+            echo "github-pages deployment state: $state"
+            case "$state" in
+              success)        break ;;
+              error|failure)  echo "::error::github-pages deployment $state"; exit 1 ;;
+            esac
+            (( $(date +%s) >= deadline )) && { echo "::error::pages deployment not done within budget"; exit 1; }
+            sleep 20
+          done
+
+          # 3) Confirm the versioned URL actually serves (covers CDN propagation).
           url="https://docs.dasch.swiss/${DSP}/"
-          deadline=$(( $(date +%s) + 300 ))  # 5-minute budget
           until curl -fsS -o /dev/null -H 'Cache-Control: no-cache' "${url}?cb=$(date +%s)"; do
-            if (( $(date +%s) >= deadline )); then
-              echo "::error::Live docs not serving at $url after 5 min; skipping announcement"
-              exit 1
-            fi
+            (( $(date +%s) >= deadline )) && { echo "::error::live docs not serving at $url within budget"; exit 1; }
             echo "waiting for $url ..."
             sleep 15
           done


### PR DESCRIPTION
Fixes two issues in the weekly dsp-docs auto-release pipeline.

## 1. Bump PR auto-merge never completes (`bump-release.yml`)

`bump-release.yml` opens the bump PR and arms auto-merge, but `main` requires **1 approving review**. The PR is authored by the **DaSCH Bot App**, which GitHub forbids from approving its own PR — so the armed auto-merge waits indefinitely (`mergeStateStatus: BLOCKED`, `reviewDecision: REVIEW_REQUIRED`) even with the `Build documentation` check green. Observed on PR #215.

**Fix:** make the **DaSCH Bot App** a **bypass actor** for the required-PR-review rule on `main` (branch-protection / ruleset config). Auto-merge then completes on green checks without a review — **no PAT, no second app, no self-approval**.

> ⚠️ Requires a one-time admin config: add the DaSCH Bot App to "Allow specified actors to bypass required pull requests" on `main`. Code-side there is nothing left to do here beyond the existing auto-merge enable.

## 2. Release announcement fires before the site is live (`deploy.yml` → `announce-release.yml`)

The public *"DSP-DOCS X released"* Chat announcement was posted as soon as `make deploy` (mike → `gh-pages`) finished. But the public site (`docs.dasch.swiss`) is published by the separate **"pages build and deployment"** workflow (github-pages environment), which lags ~10 min — so the announcement and its "Live docs" link arrived before the page served.

**Fix:** move the announcement into a new **event-driven** workflow `announce-release.yml`, triggered on the github-pages `deployment_status == success` event (fires only when the site is live — no polling/runner idle). The DSP version is resolved from the `latest`-aliased entry in gh-pages `versions.json` (since `make deploy` runs `mike deploy <DSP> latest --update-aliases`). Wording is *"released and deployed"*.

`deploy.yml` now only builds/deploys + raises an internal alert on deploy failure.

## Note

This does not retroactively fix the already-merged #215 — these apply from the next bump onward. `deployment_status`-triggered workflows run from the default branch, so #2 takes effect once merged to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)